### PR TITLE
Шахматное поле.

### DIFF
--- a/CSS_CHESS_NEW/index.html
+++ b/CSS_CHESS_NEW/index.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>CSS_CHESS</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+<body>
+    <table class="CHESS">
+        <tr>
+          <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+        <tr>
+          <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+        <tr>
+          <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+        <tr>
+          <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+        <tr>
+          <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+        <tr>
+          <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+        <tr>
+          <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+        <tr>
+          <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+        <tr>
+          <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+        <tr>
+          <td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td><td></td>
+        </tr>
+        </table>  
+</body>
+</html>

--- a/CSS_CHESS_NEW/style.css
+++ b/CSS_CHESS_NEW/style.css
@@ -1,0 +1,31 @@
+table.CHESS {
+    border-collapse: collapse;
+}
+
+table.CHESS td {
+    border: solid black 1px;
+    width: 50px;
+    height: 50px;
+}
+
+tr:nth-child(odd) td:nth-child(even) {
+    background-color: black;
+}
+
+tr:nth-child(even) td:nth-child(odd) {
+    background-color: black;
+} 
+
+.CHESS tr:first-of-type td,
+.CHESS tr:last-of-type td {
+    background-color:green;
+    width: 25px;
+    height: 25px;
+}
+
+.CHESS tr td:first-of-type,
+.CHESS tr td:last-of-type {
+    background-color:green;
+    width: 25px;
+    height: 25px;
+}  


### PR DESCRIPTION
Есть HTML-вёрстка простой таблицы 10х10. Ничего не меняя в HTML-коде, добавляя только стилевые описания в тег STYLE, привести таблицу к заданному в учебнике виду.
Селекторы псевдоклассов :not, :nth-(i) и :nth-(an+b) не использовать.
Селекторы псевдоклассов :first-, :last-, :nth-(odd) и :nth-(even) использовать можно.